### PR TITLE
Update scam.csv - remove virus.sucks

### DIFF
--- a/scam.csv
+++ b/scam.csv
@@ -2434,7 +2434,6 @@ village.elrant.team
 vincentbaldoodles.etsy.com
 vipticketgiveaway.com
 virpropcnow.xyz
-virus.sucks
 visit.hackbase
 visit.hackbase.hns.to
 vitaquiz.de


### PR DESCRIPTION
I stumbled over this while searching github for the virus.sucks homepage and app code.

See https://virus.sucks/ - this site is not a scam, not malicious and not dubious, but legitimate and very helpful.

It is a site of 2 known people from germany who did a lot of work related to the pluslife medical / biotech device, helping lots of people who use it to detect SARS-CoV2 or other viruses with their site, which hosts an FAQ and a web app.